### PR TITLE
Creation of init and basic script, adapt install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# ./scripts/install_docker.sh
+./scripts/install_basics.sh && ./scripts/install_docker.sh
 
 if [ ! -f VERSION ]; then
     echo "Missing VERSION file"
@@ -28,4 +28,4 @@ cat env.tpl >> .env
 mkdir -p certs
 cp key.json certs/key.json
 
-echo "Ready, run docker-compose up -d"
+echo "Ready, browse to /carto-selfhosted and run docker-compose up -d"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+command_available() {
+  type "$1" >/dev/null 2>&1
+}
+
+package_manager(){
+    os_release=$(ls /etc/*release /etc/*version | xargs -n 1 basename | grep -ie 'redhat*\|arch*\|gentoo*\|SuSE*\|debian*')
+
+    case $os_release in
+        redhat-release) echo yum ;;
+        arch-release) echo pacman ;;
+        gentoo-release) echo emerge ;;
+        SuSE-release) echo zypp ;;
+        debian_version) echo apt-get ;;
+        *) echo "OS not recognized, please contact CARTO at enterprise-support@carto.com" && exit 1
+    esac
+}
+
+if ! command_available git
+then
+    pm=$(package_manager)
+    sudo $pm update && sudo $pm -y install git
+fi
+
+if ! command_available curl
+then
+    pm=$(package_manager)
+    sudo $pm update && sudo $pm -y install curl
+fi
+
+sleep 30
+
+git clone https://github.com/CartoDB/carto-selfhosted.git /carto-selfhosted
+
+sleep 30
+
+mv key.json customer.env /carto-selfhosted && cd /carto-selfhosted && ./install.sh
+

--- a/scripts/install_basics.sh
+++ b/scripts/install_basics.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+command_available() {
+  type "$1" >/dev/null 2>&1
+}
+
+package_manager(){
+    os_release=$(ls /etc/*release /etc/*version | xargs -n 1 basename | grep -ie 'redhat*\|arch*\|gentoo*\|SuSE*\|debian*')
+    
+    case $os_release in
+        redhat-release) echo yum ;;
+        arch-release) echo pacman ;;
+        gentoo-release) echo emerge ;;
+        SuSE-release) echo zypp ;;
+        debian_version) echo apt-get ;;
+        *) echo "OS not recognized, please contact CARTO at enterprise-support@carto.com" && exit 1
+    esac
+}
+
+if ! command_available git
+then
+    pm=$(package_manager)
+    sudo $pm update && sudo $pm -y install git
+fi
+
+if ! command_available curl
+then
+    pm=$(package_manager)
+    sudo $pm update && sudo $pm -y install curl
+fi
+


### PR DESCRIPTION
Created a script to install git & curl (in case is necessary)
Created a centralized script to rule them all:
- Send the contents of the package and the init.sh script to the user
- Launch `./init.sh`
- Move to `cd /carto-selfhosted`
- Launch `docker-compose up -d`

cc @pablomoniz @ilbambino