### PR TITLE
Change docker-compose minimum requirements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,8 @@
 
 DOCKER_MINIMUM_VERSION_MAJOR=20
 DOCKER_MINIMUM_VERSION_MINOR=10
-COMPOSE_MINIMUM_VERSION_MAJOR=2
-COMPOSE_MINIMUM_VERSION_MINOR=1
+COMPOSE_MINIMUM_VERSION_MAJOR=1
+COMPOSE_MINIMUM_VERSION_MINOR=29
 
 check_docker_version() {
     docker_version_major=$(docker --version | awk  '{ print $3}' | awk -F. '{ print $1 }')
@@ -27,7 +27,7 @@ check_docker_version() {
 
 check_compose_version() {
     # Docker Compose version v2.1.1
-    # docker-compose version 1.29.2, build unknown
+    # docker-compose version 1.29.2, build 5becea4c
     compose_version_extracted=$(docker-compose --version | sed 's/^.*version\ //g' | sed 's/[\,\ ].*$//g' | sed 's/v//g')
     compose_version_major=$(echo "${compose_version_extracted}" | awk -F. '{ print $1 }')
     compose_version_minor=$(echo "${compose_version_extracted}" | awk -F. '{ print $2 }')


### PR DESCRIPTION
After checking an installation with `docker-compose` version 1.29.2 (https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/support-20211229-carto-selfhosted-installation-test-1?project=cartodb-on-gcp-strategic-sol), we can verify that carto-selfhosted works with this version as well.

We've changed the script because the official guide in docker's page (https://docs.docker.com/compose/install/) gives instructions to install version 1.29.2 and can result in problems with the clients.