### PR TITLE
Auto create releases

### DIFF
--- a/.github/workflow/autotag.yml
+++ b/.github/workflow/autotag.yml
@@ -1,0 +1,29 @@
+name: "Auto create release"
+on:
+  push:
+    branches:
+      - main
+    path:
+      - '/VERSION'
+jobs:
+  create-tag:
+    timeout-minutes: 3
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Retrieve Release Name
+        id: info
+        shell: bash
+        run: |
+          set -ex
+          export RELEASE_NAME=$(cat VERSION)
+          echo "::set-output name=release_name::${RELEASE_NAME}"
+      - uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit: ${{ github.sha }}
+          name: ${{ steps.info.outputs.release_name }}
+          tag: ${{ steps.info.outputs.release_name }}
+          # draft: true
+          prerelease: true
+          body: |
+            Released the `${{ steps.info.outputs.release_name }}` version

--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -2,7 +2,7 @@ name: "Auto create release"
 on:
   push:
     branches:
-      - main
+      - master
     path:
       - '/VERSION'
 jobs:
@@ -10,6 +10,8 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Retrieve Release Name
         id: info
         shell: bash


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/cartoteam/story/200234/tag-repo-on-self-hosted-release

Auto create tag & release when a new `VERSION` is merged to `master`.