### PR TITLE
Add support for Azure Postgres and external Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Deploy CARTO in a self hosted environment. It is provided in two flavours:
 
 Both flavours are recomended to be installed using external and managed databases (Postgres and Redis). The versions recommended are:
 
-- Redis 5.x
-- Postgres 13
+- Redis +5
+- Postgres +11
 
 For development and testing purposues there is an option to use databases inside the deployment. But be aware that no backup, recovery, encryption… is provided.
 
@@ -47,7 +47,22 @@ Follow the instrucions from the [helm chart](https://github.com/CartoDB/carto-se
       LOCAL_POSTGRES_SCALE=0
       WORKSPACE_POSTGRES_HOST=<FILL_ME>
       WORKSPACE_POSTGRES_PORT=<FILL_ME>
+      WORKSPACE_POSTGRES_USER=<FILL_ME>
+      WORKSPACE_POSTGRES_PASSWORD=<FILL_ME>
+      POSTGRES_ADMIN_USER=<FILL_ME>
       POSTGRES_ADMIN_PASSWORD=<FILL_ME>
+    ```
+
+    > Note: In case you are using a Postgres hosted on Azure, you should add two additional env vars. When connecting to Azure Postgres the connection user name it's different that the iternal user name, so we need to differentiate between those users, where
+
+    > `WORKSPACE_POSTGRES_INTERNAL_USER` - same value as `WORKSPACE_POSTGRES_USER` but without the `@db-name` prefix
+
+    > `POSTGRES_LOGIN_USER` - same value as `POSTGRES_ADMIN_USER` but without the `@db-name` prefix
+
+    ```bash
+      # In case your Postgres it's hosted on Azure you should add 2 additional env vars
+      WORKSPACE_POSTGRES_INTERNAL_USER=<FILL_ME>
+      POSTGRES_LOGIN_USER=<FILL_ME>
     ```
 
     - Only for local database (this should be used only in development/testing environments) container: Follow the instructions in the .env file (comment and uncomment the vars as in the example below):
@@ -57,6 +72,9 @@ Follow the instrucions from the [helm chart](https://github.com/CartoDB/carto-se
       # LOCAL_POSTGRES_SCALE=0
       # WORKSPACE_POSTGRES_HOST=<FILL_ME>
       # WORKSPACE_POSTGRES_PORT=<FILL_ME>
+      # WORKSPACE_POSTGRES_USER=<FILL_ME>
+      # WORKSPACE_POSTGRES_PASSWORD=<FILL_ME>
+      # POSTGRES_ADMIN_USER=<FILL_ME>
       # POSTGRES_ADMIN_PASSWORD=<FILL_ME>
 
       # Configuration for using a local postgres, instead of a external one (comment when external db)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Deploy CARTO in a self hosted environment. It is provided in two flavours:
 
 Both flavours are recomended to be installed using external and managed databases (Postgres and Redis). The versions recommended are:
 
-- Redis +5
+- Redis +6
 - Postgres +11
 
 For development and testing purposues there is an option to use databases inside the deployment. But be aware that no backup, recovery, encryption… is provided.
@@ -82,6 +82,31 @@ Follow the instrucions from the [helm chart](https://github.com/CartoDB/carto-se
       WORKSPACE_POSTGRES_HOST=workspace-postgres
       WORKSPACE_POSTGRES_PORT=5432
       POSTGRES_ADMIN_PASSWORD=someRandomPasswordPrefilled
+    ```
+
+    - For managed/external redis: Configure the managed redis to use for workspace by filling these variables:
+
+    ```bash
+      # Your custom configuration for a external redis (comment when local redis)
+      LOCAL_REDIS_SCALE=0
+      REDIS_HOST=<FILL_ME>
+      REDIS_PORT=<FILL_ME>
+      REDIS_PASSWORD=<FILL_ME>
+    ```
+
+    - Only for local redis (this should be used only in development/testing environments) container: Follow the instructions in the .env file (comment and uncomment the vars as in the example below):
+
+    ```bash
+    # Your custom configuration for a external redis (comment when local redis)
+    # LOCAL_REDIS_SCALE=0
+    # REDIS_HOST=<FILL_ME>
+    # REDIS_PORT=<FILL_ME>
+    # REDIS_PASSWORD=<FILL_ME>
+
+    # Configuration for using a local redis, instead of a external one (comment when external redis)
+    LOCAL_REDIS_SCALE=1
+    REDIS_HOST=redis
+    REDIS_PORT=6379
     ```
 
     - Configure the domain used. The value `SELFHOSTED_DOMAIN` should be the domain that will point to this installation (by default the domain will be `carto3-onprem.lan` with a self signed certificate)

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Follow the instrucions from the [helm chart](https://github.com/CartoDB/carto-se
       LOCAL_POSTGRES_SCALE=0
       WORKSPACE_POSTGRES_HOST=<FILL_ME>
       WORKSPACE_POSTGRES_PORT=<FILL_ME>
-      WORKSPACE_POSTGRES_USER=<FILL_ME>
+      WORKSPACE_POSTGRES_USER=workspace_admin
       WORKSPACE_POSTGRES_PASSWORD=<FILL_ME>
+      WORKSPACE_POSTGRES_DB=workspace
       POSTGRES_ADMIN_USER=<FILL_ME>
       POSTGRES_ADMIN_PASSWORD=<FILL_ME>
     ```
@@ -72,8 +73,9 @@ Follow the instrucions from the [helm chart](https://github.com/CartoDB/carto-se
       # LOCAL_POSTGRES_SCALE=0
       # WORKSPACE_POSTGRES_HOST=<FILL_ME>
       # WORKSPACE_POSTGRES_PORT=<FILL_ME>
-      # WORKSPACE_POSTGRES_USER=<FILL_ME>
+      # WORKSPACE_POSTGRES_USER=workspace_admin
       # WORKSPACE_POSTGRES_PASSWORD=<FILL_ME>
+      # WORKSPACE_POSTGRES_DB=workspace
       # POSTGRES_ADMIN_USER=<FILL_ME>
       # POSTGRES_ADMIN_PASSWORD=<FILL_ME>
 
@@ -81,6 +83,10 @@ Follow the instrucions from the [helm chart](https://github.com/CartoDB/carto-se
       LOCAL_POSTGRES_SCALE=1
       WORKSPACE_POSTGRES_HOST=workspace-postgres
       WORKSPACE_POSTGRES_PORT=5432
+      WORKSPACE_POSTGRES_USER=workspace_admin
+      WORKSPACE_POSTGRES_PASSWORD=someRandomPasswordPrefilled
+      WORKSPACE_POSTGRES_DB=workspace
+      POSTGRES_ADMIN_USER=postgres
       POSTGRES_ADMIN_PASSWORD=someRandomPasswordPrefilled
     ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
         max-file: "20"
 
   redis:
-    scale: "${LOCAL_POSTGRES_SCALE}"
+    scale: "${LOCAL_REDIS_SCALE}"
     image: "redis:5.0-alpine"
     env_file:
       - .env


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/216723/test-helm-chart-in-aks
- Autolink: [sc-216723]

Allow using in Carto self-hosted (docker-compose)

+ External Azure Postgresql
+ External Redis

Related PRs
- https://github.com/CartoDB/cloud-native/pull/5253

## Type of change

- Feature
- Refactor
