### PR TITLE
adding upgrade script command

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+ORG_FILE='.env'
+RECORD_FILE=$(date '+%Y%m%d')
+RECORD_FOLDER='PAST_ENV'
+
+cp -R $ORG_FILE $RECORD_FILE
+
+echo $RECORD_FILE
+
+if [ -d $RECORD_FOLDER ] 
+then
+	mv $RECORD_FILE $RECORD_FOLDER
+	echo "$ORG_FILE recorded in $RECORD_FOLDER"
+else
+	mkdir $RECORD_FOLDER
+	mv $RECORD_FILE $RECORD_FOLDER
+    echo "$ORG_FILE recorded in $RECORD_FOLDER"
+fi
+
+git pull
+
+./install.sh
+
+docker-compose up -d
+
+echo "Upgrade Complete"


### PR DESCRIPTION
Here is the upgrade script for self-host.

As we talked about this will make a copy of the existing `.env` files and saved them for the record then would just run the upgrade commands by running the script.

Successfully updated [this VM v2022011302](https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/selfhost-docker-upgrade?project=cartodb-on-gcp-strategic-sol&tab=details)

Looks to have a limit on which VMs can be updated since tried on [v20211118](https://console.cloud.google.com/compute/machineImages/details/self-host-docker-v20211118?project=cartodb-on-gcp-strategic-sol) without luck
