### PR TITLE
Fix missing POSTGRES_PASSWORD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,9 @@ services:
     volumes:
       - workspace-pgdata:/var/lib/postgresql/data
     restart: unless-stopped
+    environment:
+      - POSTGRES_PASSWORD=$POSTGRES_ADMIN_PASSWORD
+      - POSTGRES_USER=$POSTGRES_ADMIN_USER
     logging:
       driver: "local"
       options:


### PR DESCRIPTION
https://app.shortcut.com/cartoteam/story/222156/hawaii-doit-environment-variable-error-on-postgresql-when-installing-self-hosted.

Adapt the docker compose to include in the embedded postgresql the required variables to set the admin user and password 

TEST:

```bash
docker exec carto-selfhosted-workspace-postgres-1 env|grep -i postgres
WORKSPACE_POSTGRES_HOST=workspace-postgres
POSTGRES_ADMIN_PASSWORD=AAAAAAAAAAA
WORKSPACE_POSTGRES_PASSWORD=************
WORKSPACE_POSTGRES_PORT=5432
LOCAL_POSTGRES_SCALE=1
POSTGRES_ADMIN_USER=postgres
POSTGRES_USER=postgres
POSTGRES_PASSWORD=AAAAAAAAAAA
WORKSPACE_POSTGRES_DB=workspace
WORKSPACE_POSTGRES_USER=workspace_admin
PGDATA=/var/lib/postgresql/data
```