### PR TITLE
README add min version for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ You will need a Linux machine with
 - 60 GB disk
 - 2 CPUs (x86)
 - 8 GB memory
-- Docker
-- Docker compose
+- Docker version 20.10 or above
+- Docker compose version 1.29 or above
 - A TLS certificate for the domain/subdomain (if not provided a self-signed one will be generated)
 - Configuration and license files received from CARTO
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The value defined at `SELFHOSTED_DOMAIN` should be the domain that points to the
 **Configuration**
 
 1. Create a `certs` folder in the current directory (`carto-selfhosted`)
-2. Copy your `<cert>.crt` and `<cert>.key` files in the `certs` folders
+2. Copy your `<cert>.crt` and `<cert>.key` files in the `certs` folders (the files must be directly accesible from the server, i.e.: not protected with password and with the proper permissions)
 3. Modify the next vars in the `customer.env` file
 
 ```diff


### PR DESCRIPTION
Adding minimum required versions for Docker & Docker compose in the documentation.

We check these versions in the install.sh script:
https://github.com/CartoDB/carto-selfhosted/blob/master/install.sh#L3-L6