### PR TITLE
fix: replace password

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,7 @@ _check_compose_version() {
 }
 
 _migrate_postgres_version_var() {
-  sed -i -e 's/POSTGRES_PASSWORD/POSTGRES_ADMIN_PASSWORD/g' customer.env
+  sed -i -e 's/^POSTGRES_PASSWORD/POSTGRES_ADMIN_PASSWORD/g' customer.env
 }
 
 _create_env_file() {


### PR DESCRIPTION
This caused the following env var `WORKSPACE_POSTGRES_PASSWORD=xxx` to be replaced by `WORKSPACE_POSTGRES_ADMIN_PASSWORD=xxx` and broke the Telus self-hosted in the last deployment (that's fine I fixed it manually in minutes).