### PR TITLE
README: change default SSL behavior for external DB

### DIFF
--- a/customizations/README.md
+++ b/customizations/README.md
@@ -189,11 +189,11 @@ WORKSPACE_POSTGRES_SSL_MODE=require
 ```
 
 > :warning: In case the SSL certificate is selfsigned or from a custom CA, you will need to configure the `WORKSPACE_POSTGRES_SSL_CA` variable.
-> 
+>
 > 1. Copy you CA `.crt` file inside `certs` folder. Rename the CA `.crt` file to `postgresql-ssl-ca.crt`.
-> 
+>
 > 2. Uncomment the `WORKSPACE_POSTGRES_SSL_CA` env var in the `customer.env` file:
-> 
+>
 >    ```diff
 >    # Only applies if Postgres SSL certificate is selfsigned, read the documentation
 >    - # WORKSPACE_POSTGRES_SSL_CA=/usr/src/certs/postgresql-ssl-ca.crt

--- a/customizations/README.md
+++ b/customizations/README.md
@@ -201,7 +201,7 @@ WORKSPACE_POSTGRES_SSL_MODE=require
 >    ```
 
 To connect to your external Postgresql without SSL, you'll need to configure `WORKSPACE_POSTGRES_SSL` variables accordingly:
-```dif
+```diff
 - WORKSPACE_POSTGRES_SSL_ENABLED=true
 - WORKSPACE_POSTGRES_SSL_MODE=require
 + WORKSPACE_POSTGRES_SSL_ENABLED=false

--- a/customizations/README.md
+++ b/customizations/README.md
@@ -181,24 +181,32 @@ Open with an editor the `customer.env` file and modify the following variables:
 
 #### Configure SSL
 
-By default CARTO Self Hosted will try to connect to your PostgreSQL without SSL. In case you want to connect via SSL, you can configure it via the following env vars:
+By default CARTO Self Hosted will try to connect to your external PostgreSQL using SSL.
 
 ```bash
 WORKSPACE_POSTGRES_SSL_ENABLED=true
 WORKSPACE_POSTGRES_SSL_MODE=require
 ```
 
-> :warning: In case you are connecting to a PostgreSQL where the SSL certificate is self signed or from a custom CA you will need to configure the `WORKSPACE_POSTGRES_SSL_CA` variable.
+> :warning: In case the SSL certificate is selfsigned or from a custom CA, you will need to configure the `WORKSPACE_POSTGRES_SSL_CA` variable.
+> 
+> 1. Copy you CA `.crt` file inside `certs` folder. Rename the CA `.crt` file to `postgresql-ssl-ca.crt`.
+> 
+> 2. Uncomment the `WORKSPACE_POSTGRES_SSL_CA` env var in the `customer.env` file:
+> 
+>    ```diff
+>    # Only applies if Postgres SSL certificate is selfsigned, read the documentation
+>    - # WORKSPACE_POSTGRES_SSL_CA=/usr/src/certs/postgresql-ssl-ca.crt
+>    + WORKSPACE_POSTGRES_SSL_CA=/usr/src/certs/postgresql-ssl-ca.crt
+>    ```
 
-1. Copy you CA `.crt` file inside `certs` folder. Rename the CA `.crt` file to `postgresql-ssl-ca.crt`.
-
-2. Uncomment the `WORKSPACE_POSTGRES_SSL_CA` env var in the `customer.env` file:
-
-   ```diff
-   # Only applies if Postgres SSL certificate is selfsigned, read the documentation
-   - # WORKSPACE_POSTGRES_SSL_CA=/usr/src/certs/postgresql-ssl-ca.crt
-   + WORKSPACE_POSTGRES_SSL_CA=/usr/src/certs/postgresql-ssl-ca.crt
-   ```
+To connect to your external Postgresql without SSL, you'll need to configure `WORKSPACE_POSTGRES_SSL` variables accordingly:
+```dif
+- WORKSPACE_POSTGRES_SSL_ENABLED=true
+- WORKSPACE_POSTGRES_SSL_MODE=require
++ WORKSPACE_POSTGRES_SSL_ENABLED=false
++ WORKSPACE_POSTGRES_SSL_MODE=disable
+```
 
 #### Azure PostgreSQL
 


### PR DESCRIPTION
Changing the [Configure SSL](https://github.com/CartoDB/carto-selfhosted#configure-ssl) on the External DB section to clarify the default behavior.