### PR TITLE
Update to `2022.6.21` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 2022.6.21 (June 21, 2022)
++ Bugs fixing and minor improvements


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/9233ca3f1c9f280133a5c3af6ee5d0a26501cb65