### PR TITLE
Update to `2022.6.21` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 2022.6.21 (June 21, 2022)
++ Bugs fixing and minor improvements


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/dac4ad04f5d2ca0e39e4e06bca208955d6cd9be9