### PR TITLE
Update to `2022.6.21` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 2022.6.21 (June 21, 2022)
++ Bugs fixing and minor improvements


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/b5bf77558da240ad3d81037f622787677d63ad01