### PR TITLE
Update to `2022.6.21` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+<!--- NEW RELEASE TEMPLATE
+## very00.fake11.version22 (January 22, 2022)
+
+NOTES:
+
+- Very importante notice
+
+FEATURES:
+- workspace: This is a very new feature (#3458)
+
+IMPROVEMENTS:
+
+- maps: This is an improvement (#4532)
+
+BUG FIXES:
+
+- imports: This is an important bug fixing (#3456)
+
+--->
+
+## 2022.6.21 (June 21, 2022)
+
+IMPROVEMENTS:
+
+- Bugs fixing and minor improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,15 @@
 ## very00.fake11.version22 (January 22, 2022)
 
 NOTES:
-
 - Very importante notice
 
 FEATURES:
 - workspace: This is a very new feature (#3458)
 
 IMPROVEMENTS:
-
 - maps: This is an improvement (#4532)
 
 BUG FIXES:
-
 - imports: This is an important bug fixing (#3456)
 
 --->
@@ -21,5 +18,4 @@ BUG FIXES:
 ## 2022.6.21 (June 21, 2022)
 
 IMPROVEMENTS:
-
 - Bugs fixing and minor improvements


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/87d62d9a003c608bc5ef53ab38940fad4cd9a600