### PR TITLE
Update to `2022.6.23` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 2022.6.21 (June 21, 2022)
++ Bugs fixing and minor improvements


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/c94e25d8c78417d1535ef39036aa106192084ed7