### PR TITLE
Change support email on error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -249,7 +249,7 @@ function _run_post_checks(){
         _err "There is no Postgres Admin password defined"
       fi
       if ! _check_min_cloud_version $MIN_VERSION $PACKAGE_VERSION  ; then
-        _err "Minimum cloud version version is $MIN_VERSION but your package was generated with $PACKAGE_VERSION Contact with support (support-team@carto.com) for further assistance."
+        _err "Minimum cloud version version is $MIN_VERSION but your package was generated with $PACKAGE_VERSION Contact with support (support@carto.com) for further assistance."
       fi
     )
   fi


### PR DESCRIPTION
We've just changed the contact email for support to avoid emails to be sent to the spam folder