### PR TITLE
Fix wrong `JAVA_OPTS` env var content for `router-metrics` for Docker self-hosted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - .env
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/usr/src/certs/key.json
-      - LS_JAVA_OPTS="-Xms512m -Xmx1024m"
+      - LS_JAVA_OPTS=-Xms512m -Xmx1024m
     volumes:
       - "${CARTO3_SELFHOSTED_VOLUMES_BASE_PATH}certs/:/usr/src/certs/:ro"
     logging:


### PR DESCRIPTION
**Error**

`router-metrics` component wasn't able to start up properly because the `LS_JAVA_OPTS` env var for Logstash wasn't set correctly


```
2023-04-11T02:32:26.749731152Z /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
  2023-04-11T02:32:26.916098144Z Error: Could not find or load main class "-Xms512m
  2023-04-11T02:32:26.916120144Z Caused by: java.lang.ClassNotFoundException: "-Xms512m
  2023-04-11T02:32:28.283116496Z Error: Could not find or load main class "-Xms512m
  2023-04-11T02:32:28.283145296Z Caused by: java.lang.ClassNotFoundException: "-Xms512m
  2023-04-11T02:32:26.750089557Z /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
  2023-04-11T02:32:26.751197373Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-carto-templates.sh
  2023-04-11T02:32:26.760917813Z 20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/pipeline/pipeline-logstash.conf.tmpl to /usr/share/logstash/pipeline/pipeline-logstash.conf
  2023-04-11T02:32:26.769071930Z 20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/config/logstash.yml.tmpl to /usr/share/logstash/config/logstash.yml
  2023-04-11T02:32:26.771917171Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/60-init-router-metrics.sh
  2023-04-11T02:32:26.782300920Z Using bundled JDK: /usr/share/logstash/jdk
  2023-04-11T02:32:27.[9639](https://github.com/CartoDB/cloud-native/actions/runs/4662958706/jobs/8254387583#step:5:9692)68408Z /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
  2023-04-11T02:32:27.963996608Z /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
  2023-04-11T02:32:27.966310841Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-carto-templates.sh
  2023-04-11T02:32:27.980227541Z 20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/pipeline/pipeline-logstash.conf.tmpl to /usr/share/logstash/pipeline/pipeline-logstash.conf
  2023-04-11T02:32:27.991074697Z 20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/config/logstash.yml.tmpl to /usr/share/logstash/config/logstash.yml
  2023-04-11T02:32:27.993917638Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/60-init-router-metrics.sh
  2023-04-11T02:32:28.005624507Z Using bundled JDK: /usr/share/logstash/jdk
  2023-04-11T02:32:29.135969156Z /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
  2023-04-11T02:32:29.136049657Z /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
  2023-04-11T02:32:29.137830583Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-carto-templates.sh
  2023-04-11T02:32:29.153254105Z 20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/pipeline/pipeline-logstash.conf.tmpl to /usr/share/logstash/pipeline/pipeline-logstash.conf
  2023-04-11T02:32:29.171918473Z 20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/config/logstash.yml.tmpl to /usr/share/logstash/config/logstash.yml
  2023-04-11T02:32:29.176821044Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/60-init-router-metrics.sh
  2023-04-11T02:32:29.453331719Z Error: Could not find or load main class "-Xms512m
  2023-04-11T02:32:29.453355019Z Caused by: java.lang.ClassNotFoundException: "-Xms512m
  2023-04-11T02:32:29.190022333Z Using bundled JDK: /usr/share/logstash/jdk
  2023-04-11T02:32:30.320705288Z /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
  2023-04-11T02:32:30.320721188Z /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
  2023-04-11T02:32:30.323012321Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-carto-templates.sh
  2023-04-11T02:32:30.333626274Z 20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/pipeline/pipeline-logstash.conf.tmpl to /usr/share/logstash/pipeline/pipeline-logstash.conf
  2023-04-11T02:32:30.342019094Z 20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/config/logstash.yml.tmpl to /usr/share/logstash/config/logstash.yml
  2023-04-11T02:32:30.345128139Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/60-init-router-metrics.sh
  2023-04-11T02:32:30.355640990Z Using bundled JDK: /usr/share/logstash/jdk
```

After applying the fix

```
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-carto-templates.sh
20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/pipeline/pipeline-logstash.conf.tmpl to /usr/share/logstash/pipeline/pipeline-logstash.conf
20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/config/logstash.yml.tmpl to /usr/share/logstash/config/logstash.yml
/docker-entrypoint.sh: Launching /docker-entrypoint.d/60-init-router-metrics.sh
Using bundled JDK: /usr/share/logstash/jdk
Sending Logstash logs to /usr/share/logstash/logs which is now configured via log4j2.properties
[2023-04-11T13:24:23,148][INFO ][logstash.runner          ] Log4j configuration path used is: /usr/share/logstash/config/log4j2.properties
[2023-04-11T13:24:23,208][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"8.6.0", "jruby.version"=>"jruby 9.3.8.0 (2.6.8) 2022-09-13 98d69c9461 OpenJDK 64-Bit Server VM 17.0.5+8 on 17.0.5+8 +indy +jit [x86_64-linux]"}
[2023-04-11T13:24:23,225][INFO ][logstash.runner          ] JVM bootstrap flags: [-Xms1g, -Xmx1g, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djruby.compile.invokedynamic=true, -XX:+HeapDumpOnOutOfMemoryError, -Djava.security.egd=file:/dev/urandom, -Dlog4j2.isThreadContextMapInheritable=true, -Xms512m, -Xmx1024m, -Djruby.regexp.interruptible=true, -Djdk.io.File.enableADS=true, --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED, --add-opens=java.base/java.security=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.nio.channels=ALL-UNNAMED, --add-opens=java.base/sun.nio.ch=ALL-UNNAMED, --add-opens=java.management/sun.management=ALL-UNNAMED]
```