### PR TITLE
Clarify docs about using custom buckets

### DIFF
--- a/customizations/README.md
+++ b/customizations/README.md
@@ -417,8 +417,6 @@ You can create and use your own storage buckets in any of the following supporte
 
    > CORS is configured at bucket level in GCS and S3, and at storage account level in Azure.
 
-   > :warning: The Imports bucket do not require CORS configuration
-
    > How do I setup CORS configuration? Check the provider docs: [GCS](https://cloud.google.com/storage/docs/configuring-cors), [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html), [Azure Storage](https://docs.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services#enabling-cors-for-azure-storage).
 
 3. Generate credentials with Read/Write permissions to access those buckets, our supported authentication methods are:

--- a/customizations/README.md
+++ b/customizations/README.md
@@ -398,6 +398,7 @@ You can create and use your own storage buckets in any of the following supporte
 #### Pre-requisites
 
 1. Create 3 buckets in your preferred Cloud provider:
+
    - Import Bucket
    - Client Bucket
    - Thumbnails Bucket.
@@ -406,7 +407,7 @@ You can create and use your own storage buckets in any of the following supporte
 
    > :warning: Map thumbnails storage objects (.png files) can be configured to be `public` (default) or `private`. In order to change this, set `WORKSPACE_THUMBNAILS_PUBLIC="false"`. For the default configuration to work, the bucket must allow public objects/blobs. Some features, such as branding and custom markers, won't work unless the bucket is public. However, there's a workaround to avoid making the whole bucket public, which requires allowing public objects, allowing ACLs (or non-uniform permissions) and disabling server-side encryption.
 
-2. CORS configuration: Thumbnails and Import buckets require having the following CORS headers configured.
+2. CORS configuration: Thumbnails and Client buckets require having the following CORS headers configured.
    - Allowed origins: `*`
    - Allowed methods: `GET`, `PUT`, `POST`
    - Allowed headers (common): `Content-Type`, `Content-MD5`, `Content-Disposition`, `Cache-Control`
@@ -415,6 +416,8 @@ You can create and use your own storage buckets in any of the following supporte
    - Max age: `3600`
 
    > CORS is configured at bucket level in GCS and S3, and at storage account level in Azure.
+
+   > :warning: The Imports bucket do not require CORS configuration
 
    > How do I setup CORS configuration? Check the provider docs: [GCS](https://cloud.google.com/storage/docs/configuring-cors), [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html), [Azure Storage](https://docs.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services#enabling-cors-for-azure-storage).
 


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/cartoteam/story/324136/fix-indosat-s-self-hosted-cors-issue

If we use custom buckets we need to add CORS policies to the Client and Thumbnails buckets, the Import bucket doesn't need to be modified