### PR TITLE
[327482] carto-selfhosted fix download customer package not working when using custom buckets

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -18,30 +18,30 @@ This tool can be used to download a newer version of the Carto selfhosted custom
 
 > | flag | description |
 > |:----:|:------------|
-> | `-d` | Directory containing the existing `carto-values.yaml` and `carto-secrets.yaml` files. |
-> | `-s` | Carto selfhosted installation mode. Use `k8s`. |
+> | `-d` | Directory containing the existing `customer.env` and `key.json` files. |
+> | `-s` | Carto selfhosted installation mode. Use `docker`. |
 
 > ```bash
-> $ ./carto-download-customer-package.sh -d /tmp/carto -s k8s
+> $ ./carto-download-customer-package.sh -d /tmp/carto -s docker
 > ```
 
 > Example output:
 >
 > ```console
-> ℹ️ selfhosted mode: k8s
+> ℹ️ selfhosted mode: docker
 > ✅ found: /tmp/carto/carto-values.yaml
 > ✅ found: /tmp/carto/carto-secrets.yaml
 > ✅ activating: service account credentials for: [serv-onp-xxx@carto-tnt-onp-xxx.iam.gserviceaccount.com]
-> Copying gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip...
+> Copying gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-docker-customer-package-xxx-2023-6-16.zip...
 > / [1 files][  2.6 KiB/  2.6 KiB]
 > Operation completed over 1 objects/2.6 KiB.
-> ✅ downloading: carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
+> ✅ downloading: carto-selfhosted-docker-customer-package-xxx-2023-6-16.zip
 >
 > ##############################################################
 > Current selfhosted version in [carto-values.yaml]: 2023.6.16
 > Latest selfhosted version downloaded: 2023-6-16
-> Downloaded file: carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
-> Downloaded from: gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
+> Downloaded file: carto-selfhosted-docker-customer-package-xxx-2023-6-16.zip
+> Downloaded from: gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-docker-customer-package-xxx-2023-6-16.zip
 > ##############################################################
 >
 > ✅ finished [0]

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,15 +15,36 @@ This tool can be used to download a newer version of the Carto selfhosted custom
 ### How to download the latest customer package
 
 1. Run the script passing the following arguments:
-   - `-d | --dir` Directory containing the existing `customer.env` and `key.json` files.
-   - `-s | --selfhosted-mode` Carto selfhosted installation mode. Use `docker`.
 
-   ```bash
-   $ ./carto-download-customer-package.sh -d /tmp/carto -s docker
-   Activated service account credentials for: [serv-onp-xxx@carto-tnt-onp-xxx.iam.gserviceaccount.com]
-   Copying gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-docker-customer-package-xxx-2022-10-18.zip...
-   / [1 files][  3.5 KiB/  3.5 KiB]                                                
-   Operation completed over 1 objects/3.5 KiB.                                      
-   ```
+> | flag | description |
+> |:----:|:------------|
+> | `-d` | Directory containing the existing `carto-values.yaml` and `carto-secrets.yaml` files. |
+> | `-s` | Carto selfhosted installation mode. Use `k8s`. |
+
+> ```bash
+> $ ./carto-download-customer-package.sh -d /tmp/carto -s k8s
+> ```
+
+> Example output:
+>
+> ```console
+> ℹ️ selfhosted mode: k8s
+> ✅ found: /tmp/carto/carto-values.yaml
+> ✅ found: /tmp/carto/carto-secrets.yaml
+> ✅ activating: service account credentials for: [serv-onp-xxx@carto-tnt-onp-xxx.iam.gserviceaccount.com]
+> Copying gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip...
+> / [1 files][  2.6 KiB/  2.6 KiB]
+> Operation completed over 1 objects/2.6 KiB.
+> ✅ downloading: carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
+>
+> ##############################################################
+> Current selfhosted version in [carto-values.yaml]: 2023.6.16
+> Latest selfhosted version downloaded: 2023-6-16
+> Downloaded file: carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
+> Downloaded from: gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
+> ##############################################################
+>
+> ✅ finished [0]
+> ```
 
 2. Unzip your customer package files and use them to update your Carto selfhosted installation.

--- a/tools/carto-download-customer-package.sh
+++ b/tools/carto-download-customer-package.sh
@@ -1,52 +1,78 @@
 #!/bin/bash
 
 ##########################################
-# Requirements: yq gsutil
+# Requirements: yq jq gsutil gcloud
 ##########################################
 DEPENDENCIES="yq jq gsutil gcloud"
 SELFHOSTED_MODE="k8s"
-FILE_DIR=""
+FILE_DIR="."
 CARTO_SERVICE_ACCOUNT_FILE="./carto-service-account.json"
 CLIENT_STORAGE_BUCKET=""
 CUSTOMER_PACKAGE_NAME_PREFIX="carto-selfhosted-${SELFHOSTED_MODE}-customer-package"
 CUSTOMER_PACKAGE_FOLDER="customer-package"
 ##########################################
 
-function check_deps()
+function _check_deps()
 {
-  for DEP in ${DEPENDENCIES}; do
-    # shellcheck disable=SC2261,SC2210
-    command -v "${DEP}" 2&>1 > /dev/null || \
-      { echo -e "\n[ERROR]: missing dependency <${DEP}>. Please, install it.\n"; exit 1;}
+  for DEP in ${DEPENDENCIES} ; do
+    if ( ! command -v "${DEP}" &>/dev/null ) ; then
+      _error "missing dependency <${DEP}>. Please, install it.\n"
+    fi
   done
 }
 
-function check_input_files()
+function _check_input_files()
 {
   # =================================
-  # $1 -> input file to validate
+  # # ARGV1 = input file to validate
   # =================================
-  if ! [ -e "$1" ]; then
-    echo -e "\n[ERROR]: unable to locate <$1>. Please check that the file exists.\n"
-    usage
-    exit 2
+  # check if the file exists
+  if [ -e "${1}" ] ; then
+    _success "found: ${1}"
+  else
+    _error "unable to locate <${1}>. Please check that the file exists.\n" 3
   fi
+  # check if the file size is greater than zero
+  [ ! -s "${1}" ] && _error "file <${1}> is empty.\n" 4
 }
 
-function usage()
+function _usage()
 {
   cat <<EOF
 
-   Usage: $PROGNAME [--dir] [dir_path] [--selfhosted-mode] [k8s|docker]
+   Usage: $PROGNAME [-d dir_path] [-s <k8s|docker>]
 
    optional arguments:
-     -h, --help             Show this help message and exit
-     -d, --dir              Folder path where both <carto-values.yaml> and <carto-secrets.yaml> are located (k8s)
-                            or where both <customer.env> and <key.json> are located (docker). 
-                            Default is current directory.
-     -s, --selfhosted-mode  Selfhosted-mode for the customer package: k8s, or docker. Default is k8s.
+     -d    Folder path where both <carto-values.yaml> and <carto-secrets.yaml> are located (k8s)
+           or where both <customer.env> and <key.json> are located (docker). 
+           Default is current directory.
+     -h    Show this help message and exit
+     -s    Selfhosted-mode for the customer package: k8s or docker.
+           Default is k8s.
 
 EOF
+}
+
+function _info() {
+  # ARGV1 = message
+  echo -e "ℹ️  ${1}"
+}
+
+function _success() {
+  # ARGV1 = message
+  echo -e "✅ ${1}"
+}
+
+function _error() {
+  # ARGV1 = message
+  # ARGV2 = arbitrary error code (default is 1)
+  local EXIT_CODE="${2:-1}"
+  RED="\033[1;31m"
+  YELLOW="\033[1;93m"
+  NONE="\033[0m"
+  echo -e "❌ ${RED}ERROR ${NONE}[${EXIT_CODE}]: ${YELLOW}${1}${NONE}"
+  _usage
+  exit "${EXIT_CODE}"
 }
 
 # ==================================================
@@ -54,108 +80,103 @@ EOF
 # ==================================================
 PROGNAME="$(basename "$0")"
 
-# use getopt and store the output into $OPTS
-# note the use of -o for the short options, --long for the long name options
-# and a : for any option that takes a parameter
-OPTS=$(getopt -o "hd:s" --long "help,dir,selfhosted-mode" -n "$PROGNAME" -- "$@")
-
-# Check getopt errors
-# shellcheck disable=SC2166,SC2181
-if [ $? -ne 0 ] ; then
-  echo -e "[ERROR]: please check input arguments."
-  usage
-  exit 1
-elif [ $# -lt 2 -o $# -gt 5 ]; then
-  usage
-  exit 1
-fi
-
-eval set -- "$OPTS"
-
-# Remove trailing slash from --dir argument
-while true; do
-  case "$1" in
-    -h | --help ) usage; exit; ;;
-    -d | --dir) FILE_DIR="${2%/}"; shift 2 ;;
-    -s | --selfhosted-mode) SELFHOSTED_MODE="$3"; shift 2 ;;
-    -- ) shift ;;
-    * ) break ;;
+# use getopts builtin to store provided options
+while getopts d:s:h OPTS ; do
+  case "${OPTS}" in
+    d) FILE_DIR="${OPTARG%/}" ;;
+    s) SELFHOSTED_MODE="${OPTARG}" ;;
+    h) _usage ; exit ;;
+    *) _error "Invalid args provided" 1
   esac
 done
 
 # ==================================================
-# main block
+# sanity checks
 # ==================================================
-# docker
-CARTO_ENV="${FILE_DIR}/customer.env"
-CARTO_SA="${FILE_DIR}/key.json"
-# k8s
-CARTO_VALUES="${FILE_DIR}/carto-values.yaml"
-CARTO_SECRETS="${FILE_DIR}/carto-secrets.yaml"
-# global
-CUSTOMER_PACKAGE_NAME_PREFIX="carto-selfhosted-${SELFHOSTED_MODE}-customer-package"
 
-# Check dependencies
-check_deps
+# Validate provided path
+[ ! -d "${FILE_DIR}" ] && _error "Directory <${FILE_DIR}> does not exist."
 
 # Validate selfhosted mode
-if [ "$(echo "${SELFHOSTED_MODE}" | grep -E "docker|k8s")" == "" ]; then
-  echo -e "\n[ERROR]: available selfhosted modes: k8s or docker\n"
-  usage
-  exit 1
-fi
+# shellcheck disable=SC2076
+[[ ! '[ "docker", "k8s" ]' =~ "\"${SELFHOSTED_MODE}\"" ]] && _error "illegal value '${SELFHOSTED_MODE}'" 2
 
-# Check that required files exist
-if [ "${SELFHOSTED_MODE}" = "k8s" ]; then
-  check_input_files "${CARTO_VALUES}"
-  check_input_files "${CARTO_SECRETS}"
-fi
-if [ "${SELFHOSTED_MODE}" = "docker" ]; then
-  check_input_files "${CARTO_ENV}"
-  check_input_files "${CARTO_SA}"
-fi
+# Check dependencies
+_check_deps
 
-# Get information from YAML files (k8s) or customer.env file (docker)
-if [ "${SELFHOSTED_MODE}" = "k8s" ]; then
-  yq ".cartoSecrets.defaultGoogleServiceAccount.value" < "${CARTO_SECRETS}" | \
-    grep -v "^$" > "${CARTO_SERVICE_ACCOUNT_FILE}"
-  CLIENT_STORAGE_BUCKET=$(yq -r ".appConfigValues.workspaceImportsBucket" < "${CARTO_VALUES}")
-  TENANT_ID=$(yq -r ".cartoConfigValues.selfHostedTenantId" < "${CARTO_VALUES}")
-  CLIENT_ID="${TENANT_ID/#onp-}" # Remove onp- prefix
-  SELFHOSTED_VERSION_CURRENT=$(yq -r ".cartoConfigValues.customerPackageVersion" < "${CARTO_VALUES}") 
-fi
+# ==================================================
+# main block
+# ==================================================
 
+_info "selfhosted mode: ${SELFHOSTED_MODE}"
+
+# global
+CUSTOMER_PACKAGE_NAME_PREFIX="carto-selfhosted-${SELFHOSTED_MODE}-customer-package"
+CARTO_ENV="${FILE_DIR}/customer.env"
+CARTO_SA="${FILE_DIR}/key.json"
+# Check that CARTO_ENV exist
+_check_input_files "${CARTO_ENV}"
+# Get information from customer.env file
 # shellcheck disable=SC1090
-if [ "${SELFHOSTED_MODE}" = "docker" ]; then
-  source "${CARTO_ENV}"
+source "${CARTO_ENV}"
+
+if [ "${SELFHOSTED_MODE}" == "docker" ] ; then
+  ENV_SOURCE="$(basename "${CARTO_ENV}")"
+  # Check that required files exist
+  _check_input_files "${CARTO_SA}"
   cp "${CARTO_SA}" "${CARTO_SERVICE_ACCOUNT_FILE}"
-  CLIENT_STORAGE_BUCKET="${WORKSPACE_IMPORTS_BUCKET}"
   TENANT_ID="${SELFHOSTED_TENANT_ID}"
   CLIENT_ID="${TENANT_ID/#onp-}" # Remove onp- prefix
   SELFHOSTED_VERSION_CURRENT="${CARTO_SELFHOSTED_CUSTOMER_PACKAGE_VERSION}"
+elif [ "${SELFHOSTED_MODE}" == "k8s" ] ; then
+  # Check that required files exist
+  CARTO_VALUES="${FILE_DIR}/carto-values.yaml"
+  CARTO_SECRETS="${FILE_DIR}/carto-secrets.yaml"
+  ENV_SOURCE="$(basename "${CARTO_VALUES}")"
+  _check_input_files "${CARTO_VALUES}"
+  _check_input_files "${CARTO_SECRETS}"
+  # Get information from YAML files (k8s)
+  yq ".cartoSecrets.defaultGoogleServiceAccount.value" < "${CARTO_SECRETS}" | \
+    grep -v "^$" > "${CARTO_SERVICE_ACCOUNT_FILE}"
+  TENANT_ID="$(yq -r ".cartoConfigValues.selfHostedTenantId" < "${CARTO_VALUES}")"
+  CLIENT_ID="${TENANT_ID/#onp-}" # Remove onp- prefix
+  SELFHOSTED_VERSION_CURRENT="$(yq -r ".cartoConfigValues.customerPackageVersion" < "${CARTO_VALUES}")"
 fi
 
+# Use carto project GCP bucket for custoemr package
+CLIENT_STORAGE_BUCKET="${SELFHOSTED_GCP_PROJECT_ID}-client-storage"
+
 # Get information from JSON service account file
-CARTO_SERVICE_ACCOUNT_EMAIL=$(jq -r ".client_email" < "${CARTO_SERVICE_ACCOUNT_FILE}")
-CARTO_GCP_PROJECT=$(jq -r ".project_id" < "${CARTO_SERVICE_ACCOUNT_FILE}")
+CARTO_SERVICE_ACCOUNT_EMAIL="$(jq -r ".client_email" < "${CARTO_SERVICE_ACCOUNT_FILE}")"
+CARTO_GCP_PROJECT="$(jq -r ".project_id" < "${CARTO_SERVICE_ACCOUNT_FILE}")"
 
 # Download the latest customer package
-gcloud auth activate-service-account "${CARTO_SERVICE_ACCOUNT_EMAIL}" \
-  --key-file="${CARTO_SERVICE_ACCOUNT_FILE}" \
-  --project="${CARTO_GCP_PROJECT}"
+STEP="activating: service account credentials for: [${CARTO_SERVICE_ACCOUNT_EMAIL}]"
+if ( gcloud auth activate-service-account "${CARTO_SERVICE_ACCOUNT_EMAIL}" --key-file="${CARTO_SERVICE_ACCOUNT_FILE}" --project="${CARTO_GCP_PROJECT}" &>/dev/null ) ; then
+  _success "${STEP}" ; else _error "${STEP}" 5
+fi
 
 # Get latest customer package version
-CUSTOMER_PACKAGE_FILE_LATEST=$(gsutil ls "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-*-*-*.zip")
-SELFHOSTED_VERSION_LATEST=$(echo "${CUSTOMER_PACKAGE_FILE_LATEST}" | grep -Eo "[0-9]+-[0-9]+-[0-9]+")
+CUSTOMER_PACKAGE_FILE_LATEST="$(gsutil ls "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-*-*-*.zip")"
+SELFHOSTED_VERSION_LATEST="$(echo "${CUSTOMER_PACKAGE_FILE_LATEST}" | grep -Eo "${CLIENT_ID}-[0-9]+-[0-9]+-[0-9]+")"
+SELFHOSTED_VERSION_LATEST="${SELFHOSTED_VERSION_LATEST/#${CLIENT_ID}-}"
+
+# Double-check customer package download URI
+[[ "${CUSTOMER_PACKAGE_FILE_LATEST}" != "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-${SELFHOSTED_VERSION_LATEST}.zip" ]] && \
+  _error "customer package download URI mismatch" 7
 
 # Download package
-gsutil cp \
-  "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-${SELFHOSTED_VERSION_LATEST}.zip" .
+STEP="downloading: $(basename "${CUSTOMER_PACKAGE_FILE_LATEST}")"
+if ( gsutil cp "${CUSTOMER_PACKAGE_FILE_LATEST}" ./ ) ; then
+  _success "${STEP}" && RC="0" ; else _error "${STEP}" 6
+fi
 
 # Print message
 echo -e "\n##############################################################"
-echo -e "Current selfhosted version in [carto-values.yaml]: ${SELFHOSTED_VERSION_CURRENT}"
+echo -e "Current selfhosted version in [${ENV_SOURCE}]: ${SELFHOSTED_VERSION_CURRENT}"
 echo -e "Latest selfhosted version downloaded: ${SELFHOSTED_VERSION_LATEST}"
 echo -e "Downloaded file: $(basename "${CUSTOMER_PACKAGE_FILE_LATEST}")"
 echo -e "Downloaded from: ${CUSTOMER_PACKAGE_FILE_LATEST}"
 echo -e "##############################################################\n"
+
+_success "finished [${RC}]\n"


### PR DESCRIPTION
## Shortcut

- Story: https://app.shortcut.com/cartoteam/story/327482/selfhosted-download-customer-package-not-working-when-using-custom-buckets
- Autolink: [sc-327482]

## Description of the change

Changes on `carto-download-customer-package.sh`:

- added macOS compatibility
- added ability to work using custom buckets: for both `docker` & `k8s`  sets `CLIENT_STORAGE_BUCKET` value based on`SELFHOSTED_GCP_PROJECT_ID` from `customer.env` file as `carto-values.yaml` settings might be overwritten by customer-provided `customization.yaml` values.

## Applicable issues

- fixes #86871

## Related changes
  - https://github.com/CartoDB/carto-selfhosted-helm/pull/378
  - https://github.com/CartoDB/carto-selfhosted-helm/pull/383
