### PR TITLE
Fix link to release notes for new releases

### DIFF
--- a/.github/workflows/release-autotag.yaml
+++ b/.github/workflows/release-autotag.yaml
@@ -44,4 +44,4 @@ jobs:
           name: ${{ steps.info.outputs.release-version }}
           tag: ${{ steps.info.outputs.release-version }}
           prerelease: ${{ steps.version.outputs.prerelease }}
-          body: "Release notes for this version are available at https://docs.carto.com/get-help/deployment-options/self-hosted/release-notes#${{ steps.version.outputs.release-version-normalized }}"
+          body: "Release notes for this version are available at https://docs.carto.com/carto-self-hosted/release-notes#${{ steps.version.outputs.release-version-normalized }}"


### PR DESCRIPTION
Fix link to release notes for new releases created by a github action.