### PR TITLE
Actualizar de ubuntu-20.04 a ubuntu-24.04

### DIFF
--- a/.github/workflows/lint-codebase.yaml
+++ b/.github/workflows/lint-codebase.yaml
@@ -2,7 +2,7 @@ name: Lint codebase
 on: [pull_request]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 

--- a/.github/workflows/release-autotag.yaml
+++ b/.github/workflows/release-autotag.yaml
@@ -7,7 +7,7 @@ on:
       - VERSION
 jobs:
   create-tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Este PR actualiza las referencias de ubuntu-20.04 a ubuntu-24.04 en los archivos de configuración.