### PR TITLE
Upgrade ubuntu-20.04 to ubuntu-24.04 runner version

### DIFF
--- a/.github/workflows/lint-codebase.yaml
+++ b/.github/workflows/lint-codebase.yaml
@@ -2,7 +2,7 @@ name: Lint codebase
 on: [pull_request]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 

--- a/.github/workflows/release-autotag.yaml
+++ b/.github/workflows/release-autotag.yaml
@@ -7,7 +7,7 @@ on:
       - VERSION
 jobs:
   create-tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/470573
- Autolink: [sc-470573]

In order to avoid deprecation and our CI/CD not running because we are using runners deprecated upgrade to the latest version available.