### PR TITLE
feat: add reverse version check in install.sh [sc-540815]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -255,6 +255,10 @@ function _run_post_checks() {
 			if ! _check_min_cloud_version $MIN_VERSION $PACKAGE_VERSION; then
 				_err "Minimum cloud version version is $MIN_VERSION but your package was generated with $PACKAGE_VERSION. Please follow the instructions to download a new version of your customer package: https://github.com/CartoDB/carto-selfhosted/tree/master/tools#download-customer-package-tool."
 			fi
+			CLOUD_VERSION=$(cat VERSION)
+			if ! _check_min_cloud_version $PACKAGE_VERSION $CLOUD_VERSION; then
+				_err "Your customer package ($PACKAGE_VERSION) is newer than this CARTO Self-Hosted version ($CLOUD_VERSION). Please update your CARTO Self-Hosted installation to version $PACKAGE_VERSION or later."
+			fi
 		)
 	fi
 }


### PR DESCRIPTION
## Summary

Add a reverse version compatibility check to `install.sh`. The existing check prevents using an old customer package with a new release, but there was no check for the opposite: using a newer customer package with an older release. This can cause silent configuration mismatches.

The new check compares `CARTO_SELFHOSTED_CUSTOMER_PACKAGE_VERSION` against the `VERSION` file and shows a clear error if the package is newer than the release.

## What Changed

**Modified:**
- `install.sh` — added reverse version check in `_run_post_checks()` using the existing `_check_min_cloud_version` helper

## How to Validate

1. Set up a scenario where `VERSION` contains an older version than `CARTO_SELFHOSTED_CUSTOMER_PACKAGE_VERSION` in the `.env`
2. Run `./install.sh`
3. Verify the error message: "Your customer package (X) is newer than this CARTO Self-Hosted version (Y)..."
4. Confirm the existing forward check still works (old package + new release → error)

## Related

- Companion PR in the main repository updates the docker-compose configuration